### PR TITLE
Remove non-Hack repo from Hack's projects.txt

### DIFF
--- a/lang/hack/projects.txt
+++ b/lang/hack/projects.txt
@@ -4,7 +4,6 @@
 https://github.com/facebookarchive/hack-example-site.git
 https://github.com/titon/framework.git
 https://github.com/facebookarchive/oss-performance.git
-https://github.com/oracle/kernel-fuzzing.git
 https://github.com/igorw/reasoned-php.git
 https://github.com/hacktx/nucleus.git
 https://github.com/vinitshahdeo/online-debate-system.git


### PR DESCRIPTION
The kernel-fuzzing repo was misidentified as a Hack repo, most likely due to its use of the .hh extension for C++ headers. Removing it resolves many parsing errors from stats.

This fix also applies for the split ocaml-tree-sitter-semgrep repo (https://github.com/returntocorp/ocaml-tree-sitter-semgrep/blob/main/lang/hack/projects.txt), so let me know if this PR should duplicated or moved to the other repo.